### PR TITLE
Encrypt non-string fields, fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 [![Build Status](https://travis-ci.org/victorparmar/mongoose-field-encryption.svg?branch=master)](https://travis-ci.org/victorparmar/mongoose-field-encryption) [![Coverage Status](https://coveralls.io/repos/github/victorparmar/mongoose-field-encryption/badge.svg?branch=master)](https://coveralls.io/github/victorparmar/mongoose-field-encryption?branch=master)
 
-A simple symmetric encryption plugin for individual fields. The goal of this plugin is to encrypt data but still allow searching over the fields. This plugin relies on the Node `crypto` module. Encryption and decryption happen transparently during save and find. 
+A simple symmetric encryption plugin for individual fields. The goal of this plugin is to encrypt data but still allow searching over fields with string values. This plugin relies on the Node `crypto` module. Encryption and decryption happen transparently during save and find. 
 
-At present this plugin only works on fields with string values. Also consider [mongoose-encryption](https://github.com/joegoldbeck/mongoose-encryption) if you have other requirements.
+As of the stable 1.0.0 release, this plugin works on individual fields of any type. However, note that for non-string fields, the original value is set to undefined after encryption. This is because if the schema has defined a field as an array, it would not be possible to replace it with a string value.
+
+Also consider [mongoose-encryption](https://github.com/joegoldbeck/mongoose-encryption) if you have other requirements.
 
 ## How it works
 
-Encryption is performed using `AES-256-CTR`. To encrypt, the relevant fields are encrypted with the provided secret and the resulting hex string is put in place of the actual value. An extra `boolean` field with the prefix `__enc_` is added to the document which indicates if the provided field is encrypted or not.
+Encryption is performed using `AES-256-CTR`. To encrypt, the relevant fields are encrypted with the provided secret and the resulting hex string is put in place of the actual value for `string` values. An extra `boolean` field with the prefix `__enc_` is added to the document which indicates if the provided field is encrypted or not. 
+
+Fields which are either objects or of a different type are converted to strings using `JSON.stringify` and the value stored in an extra marker field of type `string` with a naming scheme of `__enc_` as prefix and `_d` as suffix on the original field name. The original field is then set to `undefined`. Please note that this might break any custom validation and application of this plugin on non-string fields needs to be done with care.
 
 ## Requirements
 
@@ -34,10 +38,14 @@ let Schema                  = mongoose.Schema;
 
 let Post = new Schema({
   title: String, 
-  message: String
+  message: String,
+  references: {
+    author: String,
+    date: Date
+  }
 });
 
-Post.plugin(mongooseFieldEncyption, {fields: ['message'], secret: 'some secret key'});
+Post.plugin(mongooseFieldEncyption, {fields: ['message', 'references'], secret: 'some secret key'});
 ```
 
 The resulting documents will have the following format:
@@ -46,15 +54,18 @@ The resulting documents will have the following format:
   _id: ObjectId,
   title: String,
   message: String, // encrypted hex value as string
-  __enc_message: true // boolean marking if the field is encrypted or not
+  __enc_message: true, // boolean marking if the field is encrypted or not
+  references: undefined, // encrypted object set to undefined
+  __enc_references: true, // boolean marking if the field is encrypted or not
+  __enc_references_d: String // encrypted hex object value as string
 }
 ```
 
-`find` works transparently and you can make new documents as normal, but you should not use the `lean` option on a find if you want the fields of the document to be decrypted. `findOne`, `findById` and `save` also all work as normal. `update` works, but you would also need to manually set the `__enc_` field value to false if you're updating an encrypted field. 
+`find` works transparently and you can make new documents as normal, but you should not use the `lean` option on a find if you want the fields of the document to be decrypted. `findOne`, `findById` and `save` also all work as normal. `update` works _only for string fields_ and you would also need to manually set the `__enc_` field value to false if you're updating an encrypted field. 
 
-From the mongoose documentation: _Note that findAndUpdate/Remove do not execute any hooks or validation before making the change in the database. If you need hooks and validation, first query for the document and then save it._
+From the mongoose package documentation: _Note that findAndUpdate/Remove do not execute any hooks or validation before making the change in the database. If you need hooks and validation, first query for the document and then save it._
 
-Also note that if you manually set the value `__enc_` prefix field to true then the encryption is not run on the corresponding field and this may result in the plaintext value being stored in the db.
+Also note that if you manually set the value `__enc_` prefix field to true then the encryption is not run on the corresponding field and this may result in the plain value being stored in the db.
 
 ### Required options
 
@@ -85,9 +96,4 @@ let decrypted = fieldEncryption.decrypt(encrypted, 'secret')); // decrypted = 's
 0. Install dependencies with `npm install` and [install mongo](http://docs.mongodb.org/manual/installation/) if you don't have it yet.
 1. Start mongo with `mongod`.
 2. Run tests with `npm test`. Additionally you can pass your own mongodb uri as an environment variable if you would like to test against your own database, for e.g. `URI='mongodb://username:password@localhost/mongoose-field-encryption-test' npm test`
-
-
-## TODO
-
-- add support for nested fields
 

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -115,7 +115,7 @@ const fieldEncryption = function(schema, options) {
           updateObj.$set[encryptedFieldName] = true;
           this.update({}, updateObj);
         } else {
-          return next(new Error('Cannot encrypt non string field'));
+          return next(new Error('Cannot apply mongoose-field-encryption plugin on update to encrypt non string fields'));
         }
       }
     }

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 
 const algorithm = 'aes-256-ctr';
 const encryptedFieldNamePrefix = '__enc_';
+const encryptedFieldDataSuffix = '_d';
 
 const encrypt = function(text, secret) {
   let cipher = crypto.createCipher(algorithm, secret)
@@ -31,7 +32,7 @@ const fieldEncryption = function(schema, options) {
   // add marker fields to schema
   for (let field of fieldsToEncrypt) {
     const encryptedFieldName = encryptedFieldNamePrefix + field;
-    const encryptedFieldData = encryptedFieldName + '_d';
+    const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
     const schemaField = {};
 
     schemaField[encryptedFieldName] = { type: Boolean };
@@ -42,13 +43,8 @@ const fieldEncryption = function(schema, options) {
   function encryptFields(obj, fields, secret) {
     for (let field of fields) {
       const encryptedFieldName = encryptedFieldNamePrefix + field;
-      const encryptedFieldData = encryptedFieldName + '_d';
-      const plainValue = obj[field];
-
-      if (!obj[encryptedFieldName] && plainValue) {
-        if (typeof plainValue === 'string') {
-          //String
-          const value = encrypt(plainValue, secret);
+      const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
+      const fieldValue = obj[field];
 
           obj[field] = value;
         } else {
@@ -133,6 +129,8 @@ const fieldEncryption = function(schema, options) {
   schema.methods.stripEncryptionFieldMarkers = function() {
     for (let field of fieldsToEncrypt) {
       let encryptedFieldName = encryptedFieldNamePrefix + field;
+      let encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
+
       this.set(encryptedFieldName, undefined);
     }
   };

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -129,6 +129,7 @@ const fieldEncryption = function(schema, options) {
       let encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
 
       this.set(encryptedFieldName, undefined);
+      this.set(encryptedFieldData, undefined);
     }
   };
 

--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -46,11 +46,12 @@ const fieldEncryption = function(schema, options) {
       const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
       const fieldValue = obj[field];
 
+      if (!obj[encryptedFieldName] && fieldValue) {
+        if (typeof fieldValue === 'string') { // handle strings separately to maintain searchability 
+          const value = encrypt(fieldValue, secret);
           obj[field] = value;
         } else {
-          //JSON
-          const value = encrypt(JSON.stringify(plainValue), secret);
-
+          const value = encrypt(JSON.stringify(fieldValue), secret);
           obj[field] = undefined;
           obj[encryptedFieldData] = value;
         }
@@ -63,20 +64,16 @@ const fieldEncryption = function(schema, options) {
   function decryptFields(obj, fields, secret) {
     for (let field of fields) {
       const encryptedFieldName = encryptedFieldNamePrefix + field;
-      const encryptedFieldData = encryptedFieldName + '_d';
+      const encryptedFieldData = encryptedFieldName + encryptedFieldDataSuffix;
 
       if (obj[encryptedFieldData]) {
-        //JSON
         const encryptedValue = obj[encryptedFieldData];
 
         obj[field] = JSON.parse(decrypt(encryptedValue, secret));
-
-        //debug
-        //console.dir(obj[field]);
-
         obj[encryptedFieldName] = false;
-      } else if (obj[encryptedFieldName]) {
-        //String
+        obj[encryptedFieldData] = '';
+
+      } else if (obj[encryptedFieldName]) { // handle strings separately to maintain searchability 
         const encryptedValue = obj[field];
 
         obj[field] = decrypt(encryptedValue, secret);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-field-encryption",
-  "version": "1.0.6",
-  "description": "A simple symmetric encryption plugin for fields with string values.",
+  "version": "1.0.0",
+  "description": "A simple symmetric encryption plugin for individual fields.",
   "main": "lib/mongoose-field-encryption.js",
   "files": [
     "lib/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-field-encryption",
-  "version": "1.0.0",
+  "version": "0.0.5",
   "description": "A simple symmetric encryption plugin for individual fields.",
   "main": "lib/mongoose-field-encryption.js",
   "files": [

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -12,19 +12,23 @@ const uri = process.env.URI || 'mongodb://localhost/mongoose-field-encryption-te
 
 describe('mongoose-field-encryption plugin db', () => {
 
-  let FieldEncryptionSchema = new mongoose.Schema({
-    toEncrypt1: { type: String, required: true },
-    toEncrypt2: { type: String, required: true }
+  let NestedFieldEncryptionSchema = new mongoose.Schema({
+    toEncryptString: { type: String, required: true },
+    toEncryptObject: {
+      nested: String,
+    },
+    toEncryptArray: [],
+    toEncryptDate: Date
   });
 
-  FieldEncryptionSchema.plugin(
+  NestedFieldEncryptionSchema.plugin(
     fieldEncryptionPlugin, {
-      fields: ['toEncrypt1', 'toEncrypt2'],
-      secret: 'letsdothis' // should ideally be process.env.SECRET
+      fields: ['toEncryptString', 'toEncryptObject', 'toEncryptArray', 'toEncryptDate'],
+      secret: 'icanhazcheezburger' // should ideally be process.env.SECRET
     }
   );
 
-  let FieldEncryption = mongoose.model('FieldEncryption', FieldEncryptionSchema);
+  let NestedFieldEncryption = mongoose.model('NestedFieldEncryption', NestedFieldEncryptionSchema);
 
   before(() => {
     return mongoose.connect(uri)
@@ -37,149 +41,149 @@ describe('mongoose-field-encryption plugin db', () => {
     mongoose.connection.close()
   });
 
-  it('should encrypt Object fields on save', () => {
+  function getSut() {
+    let sut = new NestedFieldEncryption({
+      toEncryptString: 'hide me!',
+      toEncryptObject: {
+        nested: 'some stuff to encrypt'
+      },
+      toEncryptArray: [1, 2, 3],
+      toEncryptDate: new Date(1970, 1, 1)
+    });
+
+    return sut;
+  }
+
+  function expectEncryptionValues(sut) {
+    expect(sut.toEncryptString).to.equal('2dc9eb06e3efa172');
+    expect(sut.__enc_toEncryptString).to.be.true;
+
+    expect(sut.toObject().toEncryptObject).to.be.undefined;
+    expect(sut.__enc_toEncryptObject).to.be.true;
+    expect(sut.__enc_toEncryptObject_d).to.equal('3e82e106b0f6a137e710374b8b3be61816e5e48dcaaeb16b57016f58ccb28a0967e4');
+
+    expect(sut.toObject().toEncryptArray).to.be.undefined;
+    expect(sut.__enc_toEncryptArray).to.be.true;
+    expect(sut.__enc_toEncryptArray_d).to.equal('1e91a351efb199');
+
+    expect(sut.toObject().toEncryptDate).to.be.undefined;
+    expect(sut.__enc_toEncryptDate).to.be.true;
+    expect(sut.__enc_toEncryptDate_d).to.equal('6791b654f3aff462e819246cd665b90855aba1db82bef5342d46');
+
+  }
+
+  function expectDecryptionValues(found) {
+    expect(found.toEncryptString).to.equal('hide me!');
+    expect(found.__enc_toEncryptString).to.be.false;
+
+    expect(JSON.stringify(found.toEncryptObject)).to.equal('{"nested":"some stuff to encrypt"}');
+    expect(found.__enc_toEncryptObject).to.be.false;
+    expect(found.__enc_toEncryptObject_d).to.equal('');
+
+    expect(JSON.stringify(found.toEncryptArray)).to.equal('[1,2,3]');
+    expect(found.__enc_toEncryptArray).to.be.false;
+    expect(found.__enc_toEncryptArray_d).to.equal('');
+
+    expect(JSON.stringify(found.toEncryptDate)).to.equal('"1970-01-31T23:00:00.000Z"');
+    expect(found.__enc_toEncryptDate).to.be.false;
+    expect(found.__enc_toEncryptDate_d).to.equal('');
+  }
+
+  it('should encrypt fields on save and decrypt fields on findById', () => {
 
     // given
-    let NestedFieldEncryptionSchema = new mongoose.Schema({
-      toEncrypt: {
-        nested: { type: String, required: true },
-        arr: [],
-        date: { type: Date }
-      }
-    });
-
-    NestedFieldEncryptionSchema.plugin(fieldEncryptionPlugin, { fields: ['toEncrypt'], secret: 'icanhazcheezburger' });
-
-    let NestedFieldEncryption = mongoose.model('NestedFieldEncryption', NestedFieldEncryptionSchema);
-
-    let sut = new NestedFieldEncryption({
-      toEncrypt: {
-        nested: 'some stuff to encrypt',
-        arr: [ 1, 2, 3 ],
-        date: new Date(1970, 1, 1)
-      }
-    });
+    let sut = getSut();
 
     // when
     return sut.save()
       .then(() => {
-        expect(sut.__enc_toEncrypt).to.be.true;
-        expect(sut.toObject().toEncrypt).to.be.undefined;
-        //TODO add correct value
-        //expect(sut.__enc_toEncrypt_d).to.equal('3e82ee11b1a0fe08f4062714d70baf1a01f0e58e8eb4e736475536168efad74f73cd436a5c1aec599940d430c43fb9408ba490ba0a2108f1dc7105ab4ce0a7d371cb0af8b4147fc584c182bded6dfe4eda50');
+        // then
+        expectEncryptionValues(sut);
 
         return NestedFieldEncryption.findById(sut._id);
       })
       .then(found => {
-        //console.dir(found.toObject());
-
-        expect(found).to.be.not.null;
-        expect(found.__enc_toEncrypt).to.be.false;
-        expect(found.toEncrypt).to.be.an('object');
-        expect(found.toEncrypt.nested).to.equal('some stuff to encrypt');
+        expectDecryptionValues(found);
       });
   });
 
   it('should encrypt fields on save and decrypt fields on findOne', () => {
 
     // given
-    let sut = new FieldEncryption({
-      toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
-    });
+    let sut = getSut()
 
     // when
     return sut.save()
       .then(() => {
-        expect(sut.__enc_toEncrypt1).to.be.true;
-        expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
-        expect(sut.__enc_toEncrypt2).to.be.true;
-        expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
-
-        return FieldEncryption.findOne({ _id: sut._id });
+        expectEncryptionValues(sut);
+        return NestedFieldEncryption.findOne({ _id: sut._id });
       })
       .then(found => {
-        expect(found.__enc_toEncrypt1).to.be.false;
-        expect(found.toEncrypt1).to.equal('some stuff');
-        expect(found.__enc_toEncrypt2).to.be.false;
-        expect(found.toEncrypt2).to.equal('should be hidden');
+        expectDecryptionValues(found);
       });
   });
 
   it('should store encrypted fields as plaintext on findOneAndUpdate', () => {
 
     // given
-    let sut = new FieldEncryption({
-      toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
-    });
+    let sut = getSut();
 
     // when
     return sut.save()
       .then(() => {
-        expect(sut.__enc_toEncrypt1).to.be.true;
-        expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
-        expect(sut.__enc_toEncrypt2).to.be.true;
-        expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
+        expectEncryptionValues(sut);
 
-        return FieldEncryption.findOneAndUpdate({ _id: sut._id }, { $set: { toEncrypt1: 'snoop', __enc_toEncrypt1: false } }, { new: true });
+        return NestedFieldEncryption.findOneAndUpdate({ _id: sut._id }, {
+          $set: { toEncryptString: 'snoop', __enc_toEncryptString: false }
+        }, { new: true });
       })
       .then(found => {
         // then
-        expect(found.__enc_toEncrypt1).to.be.false;
-        expect(found.toEncrypt1).to.equal('snoop');
-        expect(found.__enc_toEncrypt2).to.be.false;
-        expect(found.toEncrypt2).to.equal('should be hidden');
+        expect(found.__enc_toEncryptString).to.be.false;
+        expect(found.toEncryptString).to.equal('snoop');
       });
   });
 
-  it('should encrypt fields on update', () => {
+  it('should encrypt string fields on update', () => {
 
     // given
-    let sut = new FieldEncryption({
-      toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
-    });
+    let sut = getSut();
 
     // when
     return sut.save()
       .then(() => {
-        expect(sut.__enc_toEncrypt1).to.be.true;
-        expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
-        expect(sut.__enc_toEncrypt2).to.be.true;
-        expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
+        expectEncryptionValues(sut);
 
-        return FieldEncryption.update({ _id: sut._id }, { $set: { toEncrypt1: 'snoop', __enc_toEncrypt1: false } });
+        return NestedFieldEncryption.update({ _id: sut._id }, { $set: { toEncryptString: 'snoop', __enc_toEncryptString: false } });
       })
       .then(() => {
-        return FieldEncryption.findById(sut._id);
+        return NestedFieldEncryption.findById(sut._id);
       })
       .then(found => {
         // then
-        expect(found.__enc_toEncrypt1).to.be.false;
-        expect(found.toEncrypt1).to.equal('snoop');
-        expect(found.__enc_toEncrypt2).to.be.false;
-        expect(found.toEncrypt2).to.equal('should be hidden');
+        expect(found.__enc_toEncryptString).to.be.false;
+        expect(found.toEncryptString).to.equal('snoop');
       });
   });
 
   it('should not encrypt non string fields on update', () => {
 
     // given
-    let sut = new FieldEncryption({
-      toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
-    });
+    let sut = getSut();
 
     // when
     return sut.save()
       .then(() => {
-        expect(sut.__enc_toEncrypt1).to.be.true;
-        expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
-        expect(sut.__enc_toEncrypt2).to.be.true;
-        expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
+        expectEncryptionValues(sut);
 
-        return FieldEncryption.update({ _id: sut._id }, { $set: { toEncrypt1: {nested: 'snoop'}, __enc_toEncrypt1: false } });
+        return NestedFieldEncryption.update({
+          _id: sut._id
+        }, {
+          $set: {
+            toEncryptObject: { nested: 'snoop' },
+            __enc_toEncryptObject: false
+          }
+        });
       })
       .then(() => {
         expect.fail('should not have updated');

--- a/test/test-db.js
+++ b/test/test-db.js
@@ -48,7 +48,7 @@ describe('mongoose-field-encryption plugin db', () => {
         nested: 'some stuff to encrypt'
       },
       toEncryptArray: [1, 2, 3],
-      toEncryptDate: new Date(1970, 1, 1)
+      toEncryptDate: new Date(1485641048338)
     });
 
     return sut;
@@ -68,7 +68,7 @@ describe('mongoose-field-encryption plugin db', () => {
 
     expect(sut.toObject().toEncryptDate).to.be.undefined;
     expect(sut.__enc_toEncryptDate).to.be.true;
-    expect(sut.__enc_toEncryptDate_d).to.equal('6791b654f3aff462e819246cd665b90855aba1db82bef5342d46');
+    expect(sut.__enc_toEncryptDate_d).to.equal('6792bf52f4aff462e8182d6cd664b90851aba1d382bdf63c2d46');
 
   }
 
@@ -84,7 +84,7 @@ describe('mongoose-field-encryption plugin db', () => {
     expect(found.__enc_toEncryptArray).to.be.false;
     expect(found.__enc_toEncryptArray_d).to.equal('');
 
-    expect(JSON.stringify(found.toEncryptDate)).to.equal('"1970-01-31T23:00:00.000Z"');
+    expect(JSON.stringify(found.toEncryptDate)).to.equal('"2017-01-28T22:04:08.338Z"');
     expect(found.__enc_toEncryptDate).to.be.false;
     expect(found.__enc_toEncryptDate_d).to.equal('');
   }

--- a/test/test-statics.js
+++ b/test/test-statics.js
@@ -11,13 +11,17 @@ const fieldEncryptionPlugin = require('../lib/mongoose-field-encryption').fieldE
 describe('mongoose-field-encryption plugin static methods', () => {
 
   let FieldEncryptionSchema = new mongoose.Schema({
+    noEncrypt: {type: String, required: true },
     toEncrypt1: { type: String, required: true },
-    toEncrypt2: { type: String, required: true }
+    toEncrypt2: { type: String, required: true },
+    toEncryptObject: {
+      nested: { type: String }
+    }
   });
 
   FieldEncryptionSchema.plugin(
     fieldEncryptionPlugin, {
-      fields: ['toEncrypt1', 'toEncrypt2'],
+      fields: ['toEncrypt1', 'toEncrypt2', 'toEncryptObject'],
       secret: 'letsdothis' // should ideally be process.env.SECRET
     }
   );
@@ -29,18 +33,30 @@ describe('mongoose-field-encryption plugin static methods', () => {
 
     // given
     let sut = new FieldEncryptionStaticsTest({
+      noEncrypt: 'clear',
       toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
+      toEncrypt2: 'should be hidden',
+      toEncryptObject: {
+        nested: 'nested'
+      }
     });
 
     // when
     sut.encryptFieldsSync();
 
     // then
+    expect(sut.noEncrypt).to.equal('clear');
+    expect(sut.__enc_noEncrypt).to.be.undefined;
+
     expect(sut.__enc_toEncrypt1).to.be.true;
     expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
+    
     expect(sut.__enc_toEncrypt2).to.be.true;
     expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
+    
+    expect(sut.__enc_toEncryptObject).to.be.true;
+    expect(sut.__enc_toEncryptObject_d).to.equal('ba305468eb2572fdace164315ba6287c6f4181');
+    expect(sut.toObject().toEncryptObject).to.be.undefined;
 
   });
 
@@ -48,8 +64,12 @@ describe('mongoose-field-encryption plugin static methods', () => {
 
     // given
     let sut = new FieldEncryptionStaticsTest({
+      noEncrypt: 'clear',
       toEncrypt1: 'some stuff',
-      toEncrypt2: 'should be hidden'
+      toEncrypt2: 'should be hidden',
+      toEncryptObject: {
+        nested: 'nested'
+      }
     });
 
     // when
@@ -57,10 +77,18 @@ describe('mongoose-field-encryption plugin static methods', () => {
     sut.encryptFieldsSync();
 
     // then
+    expect(sut.noEncrypt).to.equal('clear');
+    expect(sut.__enc_noEncrypt).to.be.undefined;
+
     expect(sut.__enc_toEncrypt1).to.be.true;
     expect(sut.toEncrypt1).to.equal('b27d5768b82263ece8bd');
+    
     expect(sut.__enc_toEncrypt2).to.be.true;
     expect(sut.toEncrypt2).to.equal('b27a5578f43537fbebfb2e365ab13977');
+    
+    expect(sut.__enc_toEncryptObject).to.be.true;
+    expect(sut.__enc_toEncryptObject_d).to.equal('ba305468eb2572fdace164315ba6287c6f4181');
+    expect(sut.toObject().toEncryptObject).to.be.undefined;
 
   });
 
@@ -68,10 +96,13 @@ describe('mongoose-field-encryption plugin static methods', () => {
 
     // given
     let sut = new FieldEncryptionStaticsTest({
+      noEncrypt: 'clear',
       toEncrypt1: 'b27d5768b82263ece8bd',
       __enc_toEncrypt1: true,
       toEncrypt2: 'b27a5578f43537fbebfb2e365ab13977',
-      __enc_toEncrypt2: true
+      __enc_toEncrypt2: true,
+      __enc_toEncryptObject: true,
+      __enc_toEncryptObject_d: 'ba305468eb2572fdace164315ba6287c6f4181'
     });
 
     // when
@@ -80,19 +111,26 @@ describe('mongoose-field-encryption plugin static methods', () => {
     // then
     expect(sut.__enc_toEncrypt1).to.be.false;
     expect(sut.toEncrypt1).to.equal('some stuff');
+
     expect(sut.__enc_toEncrypt2).to.be.false;
     expect(sut.toEncrypt2).to.equal('should be hidden');
 
+    expect(sut.__enc_toEncryptObject).to.be.false;
+    expect(sut.__enc_toEncryptObject_d).to.equal('');
+    expect(JSON.stringify(sut.toEncryptObject)).to.equal('{"nested":"nested"}');
   });
 
   it('should ignore multiple decrypt field calls', () => {
 
     // given
     let sut = new FieldEncryptionStaticsTest({
+      noEncrypt: 'clear',
       toEncrypt1: 'b27d5768b82263ece8bd',
       __enc_toEncrypt1: true,
       toEncrypt2: 'b27a5578f43537fbebfb2e365ab13977',
-      __enc_toEncrypt2: true
+      __enc_toEncrypt2: true,
+      __enc_toEncryptObject: true,
+      __enc_toEncryptObject_d: 'ba305468eb2572fdace164315ba6287c6f4181'
     });
 
     // when
@@ -102,8 +140,13 @@ describe('mongoose-field-encryption plugin static methods', () => {
     // then
     expect(sut.__enc_toEncrypt1).to.be.false;
     expect(sut.toEncrypt1).to.equal('some stuff');
+
     expect(sut.__enc_toEncrypt2).to.be.false;
     expect(sut.toEncrypt2).to.equal('should be hidden');
+
+    expect(sut.__enc_toEncryptObject).to.be.false;
+    expect(sut.__enc_toEncryptObject_d).to.equal('');
+    expect(JSON.stringify(sut.toEncryptObject)).to.equal('{"nested":"nested"}');
 
   });
 
@@ -111,10 +154,16 @@ describe('mongoose-field-encryption plugin static methods', () => {
 
     // given
     let sut = new FieldEncryptionStaticsTest({
+      noEncrypt: 'clear',
       toEncrypt1: 'blah',
       __enc_toEncrypt1: false,
       toEncrypt2: 'yo',
-      __enc_toEncrypt2: false
+      __enc_toEncrypt2: false,
+      toEncryptObject: {
+        nested: 'nested'
+      },
+      __enc_toEncryptObject: false,
+      __enc_toEncryptObject_d: ''
     });
 
     // when
@@ -123,9 +172,13 @@ describe('mongoose-field-encryption plugin static methods', () => {
     // then
     expect(sut.__enc_toEncrypt1).to.be.undefined;
     expect(sut.toEncrypt1).to.equal('blah');
+    
     expect(sut.__enc_toEncrypt2).to.be.undefined;
     expect(sut.toEncrypt2).to.equal('yo');
 
+    expect(sut.__enc_toEncryptObject).to.be.undefined;
+    expect(sut.__enc_toEncryptObject_d).to.be.undefined;
+    expect(JSON.stringify(sut.toEncryptObject)).to.equal('{"nested":"nested"}');
   });
 
 


### PR DESCRIPTION
- add `__enc_fieldName_d` marker to store encrypted data for non-string fields
- handle string fields separately to maintain searchability