### PR TITLE
add mongoose 4-5 compatibility

### DIFF
--- a/lib/mongoose-field-encryption.js
+++ b/lib/mongoose-field-encryption.js
@@ -29,6 +29,24 @@ const fieldEncryption = function(schema, options) {
   const fieldsToEncrypt = options.fields || [];
   const secret = options.secret;
 
+  // for mongoose 4/5 compatibility
+  const defaultNext = function defaultNext(err) {
+    if (err) { throw err }
+  }
+  function getCompatitibleNextFunc(next) {
+    if (typeof next !== 'function') {
+      return defaultNext;
+    }
+    return next;
+  }
+  function getCompatibleData(next, data) {
+    // in mongoose5, 'data' field is undefined
+    if (!data) {
+      return next;
+    }
+    return data;
+  }
+
   // add marker fields to schema
   for (let field of fieldsToEncrypt) {
     const encryptedFieldName = encryptedFieldNamePrefix + field;
@@ -47,7 +65,7 @@ const fieldEncryption = function(schema, options) {
       const fieldValue = obj[field];
 
       if (!obj[encryptedFieldName] && fieldValue) {
-        if (typeof fieldValue === 'string') { // handle strings separately to maintain searchability 
+        if (typeof fieldValue === 'string') { // handle strings separately to maintain searchability
           const value = encrypt(fieldValue, secret);
           obj[field] = value;
         } else {
@@ -73,7 +91,7 @@ const fieldEncryption = function(schema, options) {
         obj[encryptedFieldName] = false;
         obj[encryptedFieldData] = '';
 
-      } else if (obj[encryptedFieldName]) { // handle strings separately to maintain searchability 
+      } else if (obj[encryptedFieldName]) { // handle strings separately to maintain searchability
         const encryptedValue = obj[field];
 
         obj[field] = decrypt(encryptedValue, secret);
@@ -82,7 +100,9 @@ const fieldEncryption = function(schema, options) {
     }
   };
 
-  schema.pre('init', function(next, data) {
+  schema.pre('init', function(_next, _data) {
+    const next = getCompatitibleNextFunc(_next)
+    const data = getCompatibleData(_next, _data)
     try {
       decryptFields(data, fieldsToEncrypt, secret);
       next();
@@ -91,7 +111,9 @@ const fieldEncryption = function(schema, options) {
     }
   });
 
-  schema.pre('save', function(next) {
+  schema.pre('save', function(_next) {
+    const next = getCompatitibleNextFunc(_next)
+
     try {
       encryptFields(this, fieldsToEncrypt, secret);
       next();
@@ -100,8 +122,8 @@ const fieldEncryption = function(schema, options) {
     }
   });
 
-  schema.pre('update', function(next) {
-
+  schema.pre('update', function(_next) {
+    const next = getCompatitibleNextFunc(_next)
     for (let field of fieldsToEncrypt) {
 
       let encryptedFieldName = encryptedFieldNamePrefix + field;


### PR DESCRIPTION
add mongoose 5 compatibility:

mongoose 5 does not have "next" function on hooks while mongoose 4 requires "next" function on hooks.

The solution is adding a 'fake' "next" function for mongoose5 for mongoose 4-5 compatibility.